### PR TITLE
bug: fix Sixpack obsolete setup (Python, deps, compose, k8s)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,30 @@
-FROM python:2.7.7
+FROM python:2.7.18
 
-MAINTAINER Leonardo Gamas <leogamas@gmail.com>
+LABEL maintainer="Leonardo Gamas <leogamas@gmail.com>"
 
-RUN pip install sixpack==2.0.2
-RUN pip install gunicorn==19.3.0
-RUN pip install gevent==1.0.1
+RUN python -m pip install --upgrade "pip<21"
 
-ENTRYPOINT ["gunicorn", "--access-logfile", "-", "-w", "8", "-b", "0.0.0.0:8000", "--worker-class=gevent"]
+# Sixpack 2.0.2 dependencies (pinned to versions that pip resolved to)
+RUN pip install \
+  hiredis==0.1.1 \
+  redis==2.9.0 \
+  mock==1.0.1 \
+  Werkzeug==0.9.1 \
+  PyYAML==3.10 \
+  Flask==0.10 \
+  Flask-SeaSurf==0.1.13 \
+  Flask-Assets==0.8 \
+  fakeredis==0.3.0 \
+  decorator==3.3.2 \
+  jsmin==2.0.2-1 \
+  python-dateutil==1.5 \
+  Markdown==2.4 \
+  Flask-DebugToolbar==0.9.0 \
+  closure==20121212
+
+# Install sixpack without pulling yuicompressor from PyPI
+RUN pip install --no-deps sixpack==2.0.2
+
+RUN pip install gunicorn==19.3.0 gevent==1.0.1
+
+CMD ["gunicorn", "--access-logfile", "-", "-w", "8", "-b", "0.0.0.0:8000", "--worker-class=gevent"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,88 @@
 # sixpack-docker
-Sixpack Dockerfile
+
+Docker image and orchestration for [Sixpack](https://github.com/seatgeek/sixpack) A/B testing service.
+
+## Overview
+
+This project provides:
+
+- **Dockerfile**: Multi-purpose image for Sixpack API and Web (Python 2.7.18, pinned dependencies, Gunicorn).
+- **Docker Compose**: Local stack with Sixpack API, Sixpack Web, and Redis.
+- **Kubernetes**: Deployment and service manifests for API and Web under `kube/`.
+
+## Requirements
+
+- Docker and Docker Compose (Compose V2)
+- For Kubernetes: `kubectl` and cluster access
+
+## Docker Compose
+
+### Starting the stack
+
+Build and start all services (API, Web, Redis):
+
+```bash
+docker compose up --build
+```
+
+- **Sixpack API**: http://localhost:5000  
+- **Sixpack Web**: http://localhost:5001  
+- **Redis**: internal only (port 6379)
+
+Run in detached mode (background):
+
+```bash
+docker compose up --build -d
+```
+
+### Stopping the stack
+
+Stop and remove containers, networks, and optionally volumes:
+
+```bash
+docker compose down
+```
+
+To also remove volumes (e.g. Redis data):
+
+```bash
+docker compose down -v
+```
+
+### Other useful commands
+
+- View logs: `docker compose logs -f`
+- Restart a service: `docker compose restart sixpackapi` or `docker compose restart sixpackweb`
+- Rebuild after Dockerfile changes: `docker compose up --build`
+
+## Image details
+
+- **Base**: `python:2.7.18`
+- **Sixpack**: 2.0.2, installed with `--no-deps`; dependencies are pinned to avoid pulling yuicompressor from PyPI.
+- **Server**: Gunicorn 19.3.0 with gevent workers (default CMD).
+- **Commands**: `sixpack` (API) and `sixpack-web` (Web) are used in Compose and Kubernetes.
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `SIXPACK_CONFIG_ENABLED` | Enable Sixpack (e.g. `true`) |
+| `SIXPACK_CONFIG_REDIS_HOST` | Redis host (e.g. `redis` in Compose) |
+| `SIXPACK_CONFIG_REDIS_PORT` | Redis port (default `6379`) |
+| `SIXPACK_CONFIG_REDIS_PREFIX` | Redis key prefix (e.g. `sixpack`) |
+| `SIXPACK_CONFIG_CSRF_DISABLE` | Disable CSRF (optional, used in Web in k8s) |
+
+## Kubernetes
+
+Manifests in `kube/`:
+
+- `sixpack-api-controller.yaml` – Deployment for API (args: `sixpack`)
+- `sixpack-web-controller.yaml` – Deployment for Web (args: `sixpack-web`)
+- `service-sixpack-api.yaml` – Service for API
+- `service-sixpack-web.yaml` – Service for Web
+
+Deployments use image `leogamas/sixpack:v0.1` and expect a Redis service (e.g. `sixpack-redis-db`).
+
+## License
+
+See the Sixpack project for license information.

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ docker compose down -v
 
 Manifests in `kube/`:
 
-- `sixpack-api-controller.yaml` – Deployment for API (`command: sixpack`)
-- `sixpack-web-controller.yaml` – Deployment for Web (`command: sixpack-web`)
+- `sixpack-api-controller.yaml` – Deployment for API (`command: sixpack`, `containerPort: 5000`)
+- `sixpack-web-controller.yaml` – Deployment for Web (`command: sixpack-web`, `containerPort: 5001`)
 - `service-sixpack-api.yaml` – Service for API (port 80 → container `targetPort: 5000`)
 - `service-sixpack-web.yaml` – Service for Web (port 80 → container `targetPort: 5001`)
 
-Deployments use image `leogamas/sixpack:v0.1` and expect a Redis service (e.g. `sixpack-redis-db`).
+Deployments use image `us.gcr.io/jusbrasil-155317/sixpack:v0.1` (Google Container Registry) and expect a Redis service (e.g. `sixpack-redis-db`).

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Build and start all services (API, Web, Redis):
 docker compose up --build
 ```
 
-- **Sixpack API**: http://localhost:5000  
-- **Sixpack Web**: http://localhost:5001  
+- **Sixpack API**: <http://localhost:5000>
+- **Sixpack Web**: <http://localhost:5001>
 - **Redis**: internal only (port 6379)
 
 Run in detached mode (background):
@@ -76,13 +76,9 @@ docker compose down -v
 
 Manifests in `kube/`:
 
-- `sixpack-api-controller.yaml` – Deployment for API (args: `sixpack`)
-- `sixpack-web-controller.yaml` – Deployment for Web (args: `sixpack-web`)
-- `service-sixpack-api.yaml` – Service for API
-- `service-sixpack-web.yaml` – Service for Web
+- `sixpack-api-controller.yaml` – Deployment for API (`command: sixpack`)
+- `sixpack-web-controller.yaml` – Deployment for Web (`command: sixpack-web`)
+- `service-sixpack-api.yaml` – Service for API (port 80 → container `targetPort: 5000`)
+- `service-sixpack-web.yaml` – Service for Web (port 80 → container `targetPort: 5001`)
 
 Deployments use image `leogamas/sixpack:v0.1` and expect a Redis service (e.g. `sixpack-redis-db`).
-
-## License
-
-See the Sixpack project for license information.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,25 @@
-sixpackapi:
-  build: .
-  command: "sixpack.server:start"
-  environment:
-    - SIXPACK_CONFIG_ENABLED=true
-    - SIXPACK_CONFIG_REDIS_PORT=6379
-    - SIXPACK_CONFIG_REDIS_HOST=redis
-    - SIXPACK_CONFIG_REDIS_PREFIX=sixpack
-  links:
-   - redis
-  ports:
-   - "5000:8000"
-sixpackweb:
-  build: .
-  command: "sixpack.web:start"
-  environment:
-    - SIXPACK_CONFIG_ENABLED=true
-    - SIXPACK_CONFIG_REDIS_PORT=6379
-    - SIXPACK_CONFIG_REDIS_HOST=redis
-    - SIXPACK_CONFIG_REDIS_PREFIX=sixpack
-  links:
-   - redis
-  ports:
-   - "5001:8000"
-redis:
-  image: redis:3.0.0
+services:
+  sixpackapi:
+    build: .
+    command: "sixpack"
+    environment:
+      - SIXPACK_CONFIG_ENABLED=true
+      - SIXPACK_CONFIG_REDIS_PORT=6379
+      - SIXPACK_CONFIG_REDIS_HOST=redis
+      - SIXPACK_CONFIG_REDIS_PREFIX=sixpack
+    ports:
+      - "5000:5000"
 
+  sixpackweb:
+    build: .
+    command: "sixpack-web"
+    environment:
+      - SIXPACK_CONFIG_ENABLED=true
+      - SIXPACK_CONFIG_REDIS_PORT=6379
+      - SIXPACK_CONFIG_REDIS_HOST=redis
+      - SIXPACK_CONFIG_REDIS_PREFIX=sixpack
+    ports:
+      - "5001:5001"
+
+  redis:
+    image: redis:4.0.14

--- a/kube/service-sixpack-api.yaml
+++ b/kube/service-sixpack-api.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
   - port: 80
     protocol: TCP
-    targetPort: 8000 
+    targetPort: 5000
   selector:
     name: sixpack-api

--- a/kube/service-sixpack-web.yaml
+++ b/kube/service-sixpack-web.yaml
@@ -8,6 +8,6 @@ spec:
   ports:
   - port: 80
     protocol: TCP
-    targetPort: 8000
+    targetPort: 5001
   selector:
     name: sixpack-web

--- a/kube/sixpack-api-controller.yaml
+++ b/kube/sixpack-api-controller.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
       - name: sixpack-api
         image: 'leogamas/sixpack:v0.1'
-        args: ["sixpack.server:start"]
+        args: ["sixpack"]
         resources:
           requests:
             memory: "128M"

--- a/kube/sixpack-api-controller.yaml
+++ b/kube/sixpack-api-controller.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
       - name: sixpack-api
         image: 'leogamas/sixpack:v0.1'
-        args: ["sixpack"]
+        command: ["sixpack"]
         resources:
           requests:
             memory: "128M"

--- a/kube/sixpack-api-controller.yaml
+++ b/kube/sixpack-api-controller.yaml
@@ -15,7 +15,7 @@ spec:
         pool: background
       containers:
       - name: sixpack-api
-        image: 'leogamas/sixpack:v0.1'
+        image: 'us.gcr.io/jusbrasil-155317/sixpack:v0.1'
         command: ["sixpack"]
         resources:
           requests:
@@ -24,7 +24,7 @@ spec:
           limits:
             memory: "256M"
         ports:
-        - containerPort: 8000
+        - containerPort: 5000
         env:
         - name: SIXPACK_CONFIG_ENABLED
           value: 'True'

--- a/kube/sixpack-web-controller.yaml
+++ b/kube/sixpack-web-controller.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
       - name: sixpack-web
         image: 'leogamas/sixpack:v0.1'
-        args: ["sixpack-web"]
+        command: ["sixpack-web"]
         resources:
           requests:
             memory: "128M"

--- a/kube/sixpack-web-controller.yaml
+++ b/kube/sixpack-web-controller.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
       - name: sixpack-web
         image: 'leogamas/sixpack:v0.1'
-        args: ["sixpack.web:start"]
+        args: ["sixpack-web"]
         resources:
           requests:
             memory: "128M"

--- a/kube/sixpack-web-controller.yaml
+++ b/kube/sixpack-web-controller.yaml
@@ -15,7 +15,7 @@ spec:
         pool: background
       containers:
       - name: sixpack-web
-        image: 'leogamas/sixpack:v0.1'
+        image: 'us.gcr.io/jusbrasil-155317/sixpack:v0.1'
         command: ["sixpack-web"]
         resources:
           requests:
@@ -24,7 +24,7 @@ spec:
           limits:
             memory: "256M"
         ports:
-        - containerPort: 8000
+        - containerPort: 5001
         env:
         - name: SIXPACK_CONFIG_ENABLED
           value: 'True'


### PR DESCRIPTION
# Bug: Fix Sixpack dead/obsolete setup (Python, deps, compose, k8s commands)

## Summary

This PR fixes the Sixpack Docker setup that was failing due to outdated Python, missing pinned dependencies, deprecated Compose format, and incorrect entrypoint commands. It also updates the README with usage and Docker Compose instructions.

## Changes

### Dockerfile
- **Base image**: Bump from `python:2.7.7` to `python:2.7.18` and upgrade pip with `pip<21`.
- **Dependencies**: Pin all Sixpack 2.0.2 dependencies explicitly (hiredis, redis, Flask, etc.) and install sixpack with `--no-deps` to avoid pulling yuicompressor from PyPI.
- **Maintainer**: Replace deprecated `MAINTAINER` with `LABEL maintainer=...`.
- **Default server**: Use `CMD` instead of `ENTRYPOINT` so Compose/Kubernetes can override with `sixpack` or `sixpack-web`.

### Docker Compose
- **Format**: Migrate to Compose v3 `services:` structure.
- **Commands**: Use `sixpack` for API and `sixpack-web` for Web (replacing `sixpack.server:start` / `sixpack.web:start`).
- **Ports**: Map API to `5000:5000` and Web to `5001:5001` (services listen on 5000 and 5001 respectively).
- **Redis**: Upgrade from `redis:3.0.0` to `redis:4.0.14`; remove deprecated `links` (Compose v3 uses internal DNS).

### Kubernetes
- **Deployments**: Use `command` (not args) for `sixpack` (API) and `sixpack-web` (Web). Set `containerPort: 5000` (API) and `containerPort: 5001` (Web).
- **Services**: Set `targetPort: 5000` (API) and `targetPort: 5001` (Web) to match container listeners.
- **Image**: Use `us.gcr.io/jusbrasil-155317/sixpack:v0.1` (GCR) instead of Docker Hub image.

### README
- Add overview, requirements, and image details.
- **Docker Compose section**: How to start (`docker compose up --build`), stop (`docker compose down`), and other useful commands.
- Document environment variables and Kubernetes manifests.
- All content in English.

## How to test

1. From the project root: `docker compose up --build`
2. Open http://localhost:5000 (API) and http://localhost:5001 (Web).
3. Stop with: `docker compose down`

## Checklist

- [x] Dockerfile builds and runs with `sixpack` and `sixpack-web` commands
- [x] Docker Compose starts API, Web, and Redis without errors
- [x] README documents Docker Compose usage and important info
- [x] Comments in Dockerfile are in English
